### PR TITLE
Allow a custom header component

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,20 @@ Title of the modal window
 
 *Default: ''*
 
+#### header
+An object that will be used to generate a custom header
+
+*Default: null*
+
+```
+header: {
+	component: 'header-component',
+	props: {
+		custom: 'Props'
+	}
+}
+```
+
 #### onClose
 Callback function to call when the modal is closed. Any given data is passed as a parameter for that callback. Example:
 

--- a/src/component.vue
+++ b/src/component.vue
@@ -127,11 +127,13 @@ export default {
 <transition tag="div" name="vuedal">
     <div class="vuedals" v-show="vuedals.length">
         <div class="vuedal" v-for="(vuedal, index) in vuedals" :key="vuedal" :class="getCssClasses(index)">
-            <header v-if="vuedal.title || vuedal.dismisable">
+            <header v-if="(vuedal.title || vuedal.dismisable) && !vuedal.header">
                 <span class="title">{{ vuedal.title }}</span>
                 <span @click="dismiss()" v-if="vuedal.dismisable" class="close">&times;</span>
             </header>
-
+            <header v-if="vuedal.header">
+                <component :is="vuedal.header.component" v-bind="vuedal.header.props"></component>
+            </header>
             <component :is="vuedal.component" v-bind="vuedal.props"></component>
         </div>
     </div>


### PR DESCRIPTION
I wanted to be able to add custom buttons/functionality into the header of the modal. This PR adds this functionality.

If the `header` option isn't specified, the default functionality is applied. If it is specified it renders the component with the props specified. For example:

```
header: {
    component: 'custom-header',
    props: {
        title: this.inf.name
    }
},
```