### PR TITLE
Fix scrolling of content behind modal

### DIFF
--- a/src/component.vue
+++ b/src/component.vue
@@ -26,6 +26,8 @@ export default {
                 options
             });
 
+            this.body.classList.add('vuedal-open');
+
             document.querySelector('.vuedals').scrollTop = 0;
         });
 
@@ -46,8 +48,10 @@ export default {
         // Remove the given index from the vuedals array
         splice(index) {
             // And if it was the last window, also notify that all instances are destroyed
-            if (index === 0)
+            if (index === 0) {
+                this.body.classList.remove('vuedal-open');
                 Bus.$emit('destroyed');
+            }
 
             if (!index) {
                 this.vuedals.pop();
@@ -118,6 +122,12 @@ export default {
         // Get the last element of the Vuedals array (the most recent Vuedal instance)
         $last() {
             return this.vuedals.length - 1;
+        },
+
+        body() {
+            if (typeof document !== 'undefined') {
+                return document.querySelector('body');
+            }
         }
     }
 }
@@ -141,6 +151,9 @@ export default {
 </template>
 
 <style lang="sass">
+body.vuedal-open {
+    overflow: hidden;
+}
 
 .vuedals {
     background-color: rgba(0,0,0,.5);


### PR DESCRIPTION
I'm using vuedals on a site with a rather long content and needed to disable the scrolling when a modal is open.

This disables scrolling of any content behind modals where the content would be scrollable and enables scrolling after the last modal is closed.

I thought this should be the standard behaviour, but if needed I could add it as a prop.

Any changes/suggestions welcome!