### PR TITLE
Listen for a close event on the component itself

### DIFF
--- a/src/component.vue
+++ b/src/component.vue
@@ -212,7 +212,7 @@ export default {
             <header v-if="vuedal.header">
                 <component :is="vuedal.header.component" v-bind="vuedal.header.props"></component>
             </header>
-            <component :is="vuedal.component" v-bind="vuedal.props"></component>
+            <component :is="vuedal.component" v-bind="vuedal.props" @close="dismiss(index)"></component>
         </div>
     </div>
 </transition>


### PR DESCRIPTION
Using `this.$emit('vuedals:close')` or `this.$vuedals.close()` works great in most cases, but sometimes it makes sense for the component that is in the modal to be able to easily close itself without worrying about whether it was the most recently opened modal.

I simply added an event listener so the component can emit a `close` event. When that happens, `dismiss` will be called with the appropriate index, no weird logic necessary.

By the way, thanks for this awesome library! This is by far the best implementation of modals in Vue that I've seen!