### PR TITLE
Allow a component to be passed to close()

### DIFF
--- a/src/component.vue
+++ b/src/component.vue
@@ -40,6 +40,16 @@ export default {
             if (data && data.$index)
                 index = data.$index;
 
+            // If a Vue component was passed as the data
+            if (data && data.$vnode) {
+                for (let [idx, vuedal] of this.$refs.components.entries()) {
+                    if (data === vuedal) {
+                        index = idx
+                        break
+                    }
+                }
+            }
+            
             if (index === null)
                 // Close the most recent Vuedal instance
                 index = this.$last;
@@ -212,7 +222,7 @@ export default {
             <header v-if="vuedal.header">
                 <component :is="vuedal.header.component" v-bind="vuedal.header.props"></component>
             </header>
-            <component :is="vuedal.component" v-bind="vuedal.props"></component>
+            <component :is="vuedal.component" v-bind="vuedal.props" ref="components"></component>
         </div>
     </div>
 </transition>

--- a/src/component.vue
+++ b/src/component.vue
@@ -41,7 +41,7 @@ export default {
                 index = data.$index;
 
             // If a Vue component was passed as the data
-            if (data && data.$vnode) {
+            if (data && data._isVue) {
                 for (let [idx, vuedal] of this.$refs.components.entries()) {
                     if (data === vuedal) {
                         index = idx


### PR DESCRIPTION
Using this.$emit('vuedals:close') or this.$vuedals.close() works great in most cases, but sometimes it makes sense for the component that is in the modal to be able to easily close itself without worrying about whether it was the most recently opened modal.

This adds the option to pass a vue component as the `data` parameter to `close()`. As an example, if a component is in a modal and wants to close itself, it doesn't need to calculate its index anymore, it can just:
```
this.$vuedals.close(this)
```

By the way, thanks for this awesome library! This is by far the best implementation of modals in Vue that I've seen!